### PR TITLE
fix automatic to explicit index parameter conversion

### DIFF
--- a/lib/src/crdt_executor.dart
+++ b/lib/src/crdt_executor.dart
@@ -3,6 +3,7 @@ import 'package:sqlparser/sqlparser.dart';
 import 'package:sqlparser/utils/node_to_text.dart';
 
 import 'database_api.dart';
+import 'sql_util.dart';
 
 final _sqlEngine = SqlEngine();
 
@@ -36,7 +37,8 @@ class CrdtTableExecutor extends _CrdtTableExecutor implements CrdtApi {
 
   @override
   Future<List<Map<String, Object?>>> query(String sql, [List<Object?>? args]) =>
-      (_db as ReadWriteApi).query(sql, args);
+      (_db as ReadWriteApi)
+          .query(SqlUtil.transformAutomaticExplicitSql(sql), args);
 }
 
 class _CrdtTableExecutor {
@@ -122,7 +124,8 @@ class CrdtExecutor extends CrdtWriteExecutor implements CrdtApi {
 
   @override
   Future<List<Map<String, Object?>>> query(String sql, [List<Object?>? args]) =>
-      (_db as ReadWriteApi).query(sql, args);
+      (_db as ReadWriteApi)
+          .query(SqlUtil.transformAutomaticExplicitSql(sql), args);
 }
 
 class CrdtWriteExecutor extends _CrdtTableExecutor {
@@ -136,6 +139,7 @@ class CrdtWriteExecutor extends _CrdtTableExecutor {
   @override
   Future<void> _executeStatement(
       Statement statement, List<Object?>? args) async {
+    SqlUtil.transformAutomaticExplicit(statement);
     final table = await switch (statement) {
       CreateTableStatement statement => _createTable(statement, args),
       InsertStatement statement => _insert(statement, args),

--- a/lib/src/sql_crdt.dart
+++ b/lib/src/sql_crdt.dart
@@ -40,7 +40,7 @@ abstract class SqlCrdt extends Crdt implements CrdtApi {
 
   @override
   Future<List<Map<String, Object?>>> query(String sql, [List<Object?>? args]) =>
-      _db.query(sql, args);
+      _db.query(SqlUtil.transformAutomaticExplicitSql(sql), args);
 
   @override
   Future<void> execute(String sql, [List<Object?>? args]) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sql_crdt
 description: Base package for Conflict-free Replicated Data Types (CRDTs) using SQL databases
-version: 3.0.2
+version: 3.0.3
 homepage: https://github.com/cachapa/sql_crdt
 repository: https://github.com/cachapa/sql_crdt
 issue_tracker: https://github.com/cachapa/sql_crdt/issues
@@ -12,7 +12,7 @@ dependencies:
   crdt: ^5.1.3
 #    path: ../crdt
   source_span: ^1.10.0
-  sqlparser: ^0.39.2
+  sqlparser: ^0.41.0
   collection: ^1.19.1
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
 #    path: ../crdt
   source_span: ^1.10.0
   sqlparser: ^0.39.2
+  collection: ^1.19.1
 
 dev_dependencies:
   lints: any


### PR DESCRIPTION
Under the hood sql_crdt operates with explicit parameter indices (?1, ?2. ?3,... ) which leads to conflicts whenever a client uses implicit parameter indexing (?, ?, ?,... ). 

This PR ensures parameter conversion from implicit to explicit.