### PR TITLE
Update sqlparser to ^0.45.0

### DIFF
--- a/lib/src/crdt_executor.dart
+++ b/lib/src/crdt_executor.dart
@@ -48,9 +48,10 @@ class _CrdtTableExecutor {
 
   Future<void> execute(String sql, [List<Object?>? args]) async {
     // Break query into individual statements
-    final statements =
-        (_sqlEngine.parseMultiple(sql).rootNode as SemicolonSeparatedStatements)
-            .statements;
+    final statements = _sqlEngine
+        .parse(ParserEntrypoint.multiple, sql)
+        .rootNode
+        .statements;
     assert(statements.length == 1,
         'This package does not support compound statements:\n$sql');
 

--- a/lib/src/sql_util.dart
+++ b/lib/src/sql_util.dart
@@ -14,8 +14,9 @@ class SqlUtil {
   /// Identifies affected tables in a given SQL statement.
   static Set<String> getAffectedTables(String sql) {
     try {
-      return _getAffectedTables(
-          _sqlEngine.parse(sql).rootNode as BaseSelectStatement);
+      return _getAffectedTables(_sqlEngine
+          .parse(ParserEntrypoint.statement, sql)
+          .rootNode as BaseSelectStatement);
     } catch (_) {
       print('Error parsing statement: $sql');
       rethrow;
@@ -40,7 +41,8 @@ class SqlUtil {
   }
 
   static String transformAutomaticExplicitSql(String sql) {
-    final statement = _sqlEngine.parse(sql).rootNode as Statement;
+    final statement =
+        _sqlEngine.parse(ParserEntrypoint.statement, sql).rootNode;
 
     // if statement is of InvalidStatement type, return the original SQL string
     if (statement is InvalidStatement) return sql;
@@ -60,7 +62,9 @@ class SqlUtil {
     assert(onlyNodeId == null || exceptNodeId == null);
     assert(modifiedOn == null || modifiedAfter == null);
 
-    final statement = _sqlEngine.parse(sql).rootNode as SelectStatement;
+    final statement = _sqlEngine
+        .parse(ParserEntrypoint.statement, sql)
+        .rootNode as SelectStatement;
 
     final clauses = [
       if (onlyNodeId != null)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   crdt: ^5.1.3
 #    path: ../crdt
   source_span: ^1.10.1
-  sqlparser: ^0.41.0
+  sqlparser: ^0.45.0
   collection: ^1.19.1
 
 dev_dependencies:


### PR DESCRIPTION
The 0.44.0 release merged SqlEngine's separate parse/parseMultiple methods into a single parse() taking a ParserEntrypoint enum. Adjust all call sites accordingly.

Details: https://github.com/simolus3/drift/blob/develop/sqlparser/CHANGELOG.md